### PR TITLE
Fix misspelling on API page

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -8,7 +8,7 @@
   "api-inspiration": "Looking for inspiration? Take a look at these outstanding apps, all built using our free API",
   "api-learn-more": "Learn More About The API",
   "api-learn-more-variant": "Learn More About The Audius API",
-  "api-reason-1": "More Then 450K Tracks",
+  "api-reason-1": "More Than 450K Tracks",
   "api-reason-2": "Zero Rate Limits",
   "api-reason-3": "Totally Free",
   "api-reason-4": "320kbps High Quality Audio",


### PR DESCRIPTION
It's a small change but it draws attention since it's written with those big fonts on the API website.
https://audius.org/api