### PR TITLE
[QA-1736] Fixes duplicate listing of second bullet point

### DIFF
--- a/pages/[locale]/token/Token.tsx
+++ b/pages/[locale]/token/Token.tsx
@@ -164,9 +164,9 @@ const Token = () => {
                 </div>
                 <div className='description'>
                   <p>
-                    <b>{t('token-stake-reason-2')}</b>
+                    <b>{t('token-stake-reason-3')}</b>
                   </p>
-                  <p>{t('token-stake-reason-2-description')}</p>
+                  <p>{t('token-stake-reason-3-description')}</p>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
The localized content already existed for the third bullet point. The component just had a typo in its references.