### PR TITLE
Add script to upload assets to wrangler kv

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "next start",
     "lint": "next lint",
     "lint:fix": "next lint --fix",
-    "publish": "npx wrangler publish",
+    "publish": "npx wrangler publish && node upload-assets.js",
     "preview": "npx wrangler preview"
   },
   "repository": {

--- a/upload-assets.js
+++ b/upload-assets.js
@@ -1,0 +1,47 @@
+const { exec } = require('child_process')
+const fs = require('fs')
+const path = require('path')
+
+// Path to your build folder
+const directoryPath = path.resolve('./out/_next/static')
+
+const kvNamespace = '7e4963ca204a4783bd576a3b361017eb'
+
+function uploadToKV(filePath, kvKey) {
+  return new Promise((resolve, reject) => {
+    const command = `npx wrangler kv key put "${kvKey}" --path "${filePath}" --namespace-id ${kvNamespace}`
+    exec(command, (error, stdout, stderr) => {
+      if (error) {
+        console.error(`Failed to upload ${kvKey}:`, error.message);
+        reject(error);
+        return;
+      }
+      console.log(`Uploaded: ${kvKey}`);
+      resolve();
+    });
+  });
+}
+
+// Recursive function to process directories
+async function processDirectory(directory) {
+  const items = fs.readdirSync(directory);
+  
+  const promises = items.map(async (item) => {
+    const fullPath = path.join(directory, item)
+    
+    if (fs.statSync(fullPath).isDirectory()) {
+      // Recursively process subdirectories
+      await processDirectory(fullPath);
+    } else {
+      // For files, create KV key relative to ./out
+      let kvKey = '_next/' + path.relative('./out/_next', fullPath).replace(/\\/g, '/')
+      kvKey = kvKey.replace('[', '%5B').replace(']', '%5D')
+      await uploadToKV(fullPath, kvKey)
+    }
+  })
+
+  await Promise.all(promises)
+}
+
+// Start processing from the static directory
+processDirectory(directoryPath)

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,11 +1,9 @@
-compatibility_date = "2024-10-25"
+compatibility_date = "2024-08-25"
 name = "audius-org-public-site"
-type = "webpack"
 account_id = "3811365464a8e56b2b27a5590e328e49"
 workers_dev = true
 
 route = "audius.org/*"
-zone_id = "5a3ccccef96ba8b3380b78451ec164e6"
 
 [site]
 bucket = "./out"


### PR DESCRIPTION
This fixes releasing of the audius.org site.
It is a really bad solution, but cloudflare seems to have given us no choice given:
- node 16
- old nextjs 11
- old wrangler sites (deprecated) `@cloudflare/wrangler 1.x`

So... the right solve is to modernize all these deps, including the language system we have. Bigger lift. For now, this good.